### PR TITLE
Chore/tech files init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI (placeholder)
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "lint OK ✅"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "tests OK ✅"
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "build OK ✅"

--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,56 @@
-# Cache and logs (Symfony2)
+# ------------------------------------------------------------------------------
+#  Symfony / PHP
+# ------------------------------------------------------------------------------
+/vendor/
+composer.phar
+# Cache & logs v2 / v3
 /app/cache/*
 /app/logs/*
 !app/cache/.gitkeep
 !app/logs/.gitkeep
-
-# Email spool folder
-/app/spool/*
-
-# Cache, session files and logs (Symfony3)
+# Cache & logs v3 / v4
 /var/cache/*
-/var/logs/*
+/var/log/*
 /var/sessions/*
 !var/cache/.gitkeep
-!var/logs/.gitkeep
-!var/sessions/.gitkeep
-
-# Logs (Symfony4)
-/var/log/*
 !var/log/.gitkeep
-
-# Parameters
+!var/sessions/.gitkeep
+# Paramètres locaux
 /app/config/parameters.yml
 /app/config/parameters.ini
-
-# Managed by Composer
-/app/bootstrap.php.cache
-/var/bootstrap.php.cache
-/bin/*
-!bin/console
-!bin/symfony_requirements
-/vendor/
-
-# Assets and user uploads
-/web/bundles/
-/web/uploads/
-
-# PHPUnit
-/app/phpunit.xml
-/phpunit.xml
-
-# Build data
-/build/
-
-# Composer PHAR
-/composer.phar
-
-# Backup entities generated with doctrine:generate:entities command
+# Doctrine : backup fichiers ~
 **/Entity/*~
+# build
+/build/
+# PHPUnit
+/phpunit.xml
+/app/phpunit.xml
 
-# Embedded web-server pid file
-/.web-server-pid
+# ------------------------------------------------------------------------------
+#  Node / Yarn / Vite
+# ------------------------------------------------------------------------------
+node_modules/
+.yarn/
+.pnpm-debug.log*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# ------------------------------------------------------------------------------
+#  Docker & divers
+# ------------------------------------------------------------------------------
+docker-compose.override.yml
+.docker/
+.env
+.env.local
+*.pid
+*.log
+*.sqlite
+.idea/
+.vscode/
+
+# ------------------------------------------------------------------------------
+#  OS
+# ------------------------------------------------------------------------------
+.DS_Store
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: up down lint test
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+lint:
+	@echo "🔧  lint placeholder – sera implémenté en F-003"
+
+test:
+	@echo "🧪  test placeholder – sera implémenté en F-003"

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use ECSPrefix202401\Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return static function (ECSConfig $ecsConfig): void {
+    // règles ajoutées dans F-003
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+includes:
+    # modules spécifiques à ajouter après F-003


### PR DESCRIPTION
## Objectif
Ajouter les fichiers techniques de base pour verrouiller l’hygiène du dépôt :
- `.gitignore` complet (PHP, Node, Docker)
- `Makefile` avec cibles placeholders (`make up`, `make down`, `make lint`, `make test`)
- Configs vierges pour PHPStan (`phpstan.neon.dist`) et ECS (`ecs.php`)

Ces fichiers évitent de versionner des artefacts et préparent le terrain pour la CI (ticket F-003).

Aucune issue – tâche d’initialisation

## Points de vérification
- [x] Linter et CI verts (pas encore de vérif lint/test, mais workflow s’exécute sans erreur)
- [x] Documentation mise à jour (README mentionne Makefile)
- [x] Aucun secret ou fichier généré commités

## Screenshots (si UI)
*(sans objet – pas de changements d’interface)*
