### PR TITLE
Feat/f 001 docker compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
-###> doctrine ###
-MYSQL_ROOT_PASSWORD=rootpass-dev
-MYSQL_PASSWORD=apppass-dev
+APP_ENV=dev
+APP_SECRET=change-me
+
+MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=app
 MYSQL_USER=app
-###< doctrine ###
+MYSQL_PASSWORD=secret

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
-.PHONY: up down lint test
+.PHONY: up down logs
 
 up:
-	docker compose up -d
+	@if [ ! -f .env ]; then cp .env.dist .env; fi
+	docker compose up -d --build
 
 down:
-	docker compose down
+	docker compose down -v
 
-lint:
-	@echo "🔧  lint placeholder – sera implémenté en F-003"
-
-test:
-	@echo "🧪  test placeholder – sera implémenté en F-003"
+logs:
+	docker compose logs -f --tail=100

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ Consulte la vision produit complète pour comprendre le « pourquoi » et les ob
 
 ---
 
+## Démarrage rapide (stack Docker Compose)
+
+> Prérequis : Docker 24 + GNU Make installés sur votre machine (Docker Desktop + WSL 2 sous Windows 11).
+
+Copiez-collez **l’intégralité** du bloc ci-dessous dans votre terminal – tout sera prêt en une seule exécution :
+
+# 1· Cloner le dépôt et entrer dans le dossier
+```bash
+git clone https://github.com/<organisation>/recherche-emploi.git
+cd recherche-emploi
+```
+# 2· Copier les variables d'environnement par défaut (à faire une seule fois)
+```bash
+cp .env.local .env
+```
+# 3· Démarrer la stack conteneurisée (PHP-FPM 8.3, Nginx 1.27, MySQL 8.4)
+```bash
+make up
+```
+
+# 4· Ouvrir l'application dans le navigateur
+#    (la page d’accueil Symfony affichera HTTP 200 dès que le code sera installé)
+xdg-open http://localhost:8000 2>/dev/null || open http://localhost:8000 || start http://localhost:8000
+
+
 ## Statut
 
 Projet en développement : dépôts, CI et fondations sont en place : [Definition of Done](./docs/DoD.md). Les premières fonctionnalités arrivent bientôt.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  php:
+    build: ./docker/php
+    volumes:
+      - .:/var/www
+    environment:
+      APP_ENV: ${APP_ENV}
+      APP_SECRET: ${APP_SECRET}
+    depends_on:
+      - mysql
+
+  nginx:
+    image: nginx:1.27-alpine
+    volumes:
+      - .:/var/www
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8000:80"        # publier sur 8000 pour éviter le port 80 de Laragon
+    depends_on:
+      - php
+
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  db_data:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    root   /var/www/public;
+    index  index.php;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass  php:9000;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include       fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param REQUEST_SCHEME $scheme;
+        fastcgi_param HTTPS $https if_not_empty;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+# Image PHP-FPM 8.3 pour Symfony – Alpine
+# -----------------------------------------------------------------------------
+FROM php:8.3-fpm-alpine
+
+# ----------------------------------------------------------------------------- 
+# 1. Paquets système + dépendances de compilation
+#    - git, unzip           : outils courants
+#    - icu-data-full        : toutes les locales ICU (utile pour intl)
+#    - .build-deps (virtual): paquets *-dev* nécessaires seulement le temps
+#      de compiler les extensions → on les supprimera ensuite pour alléger.
+# -----------------------------------------------------------------------------
+RUN apk add --no-cache git unzip icu-data-full \
+ && apk add --no-cache --virtual .build-deps icu-dev
+
+# -----------------------------------------------------------------------------
+# 2. Extensions PHP
+# -----------------------------------------------------------------------------
+RUN docker-php-ext-install pdo_mysql intl opcache
+
+# On retire les dépendances de build pour réduire la taille finale
+RUN apk del .build-deps
+
+# -----------------------------------------------------------------------------
+# 3. Composer (copié depuis l’image officielle)
+# -----------------------------------------------------------------------------
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# -----------------------------------------------------------------------------
+# 4. Utilisateur non-root + code applicatif
+# -----------------------------------------------------------------------------
+WORKDIR /var/www
+COPY . /var/www
+
+RUN addgroup -g 1000 symfony \
+ && adduser  -G symfony -u 1000 -D symfony \
+ && chown -R symfony:symfony /var/www
+USER symfony
+
+# -----------------------------------------------------------------------------
+# 5. Point d’entrée
+# -----------------------------------------------------------------------------
+CMD ["php-fpm"]


### PR DESCRIPTION
## Objectif
Mettre en place un environnement conteneurisé « one-command » afin que tout·e développeur·euse puisse lancer l’application localement sans configuration manuelle.

Cette PR ajoute :
* `docker-compose.yml` (PHP-FPM 8.3, Nginx 1.27, MySQL 8.4)  
* `docker/php/Dockerfile` avec extensions `pdo_mysql`, `intl`, `opcache`  
* `Makefile` (`make up`, `make down`, `make logs`)  
* `.env.dist` centralisant les variables d’environnement  
* Volume persistant `db_data` et exposition des ports 8000→80 et 3306→3306  

## Lié à
Closes #5

## Points de vérification
- [ ] Tests unitaires et intégration passent (`make test`)
- [ ] Linter et CI verts
- [x] Documentation mise à jour (README section “Démarrage rapide”)
- [x] Aucun secret ou fichier généré commités

## Screenshots (si UI)
_Non applicable – feature pure infra._
