### PR TITLE
Feat/f 008 pre-commit (make lint) + CI lint (ECS & PHPStan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,11 @@ env:
   COMPOSER_ALLOW_SUPERUSER: "1"
 
 jobs:
-  #############################################################################
-  # 1) Analyse statique – PHPStan
-  #############################################################################
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # Fournir les fichiers d'env attendus par docker-compose
       - name: Prepare env for CI (.env.dist + .env)
         run: |
           cat > .env.dist <<'EOF'
@@ -27,13 +23,11 @@ jobs:
           MYSQL_USER=app
           MYSQL_PASSWORD=app
           MYSQL_DATABASE=app
-
           APP_ENV=dev
           APP_DEBUG=0
           MAILER_DSN=null://localhost
           PMA_HOST=mysql
           PMA_PORT=3306
-
           DATABASE_URL="mysql://app:app@mysql:3306/app?serverVersion=8.4.5&charset=utf8mb4"
           EOF
           cp .env.dist .env
@@ -52,23 +46,27 @@ jobs:
             -e COMPOSER_ALLOW_SUPERUSER="$COMPOSER_ALLOW_SUPERUSER" \
             php sh -lc "git config --global --add safe.directory /var/www && composer install -n --prefer-dist --no-scripts"
 
-      - name: Run PHPStan
+      - name: ECS check
         env:
           WORKDIR: ${{ env.WORKDIR }}
         run: |
           docker compose run --rm --no-deps --entrypoint "" \
             --workdir "$WORKDIR" \
-            php sh -lc "vendor/bin/phpstan analyse --level max"
+            php sh -lc "php vendor/bin/ecs check --config=/var/www/ecs.php --no-interaction"
 
-  #############################################################################
-  # 2) Tests unitaires – PHPUnit
-  #############################################################################
+      - name: PHPStan analyse
+        env:
+          WORKDIR: ${{ env.WORKDIR }}
+        run: |
+          docker compose run --rm --no-deps --entrypoint "" \
+            --workdir "$WORKDIR" \
+            php sh -lc "php vendor/bin/phpstan analyse -c /var/www/app/phpstan.dist.neon --no-progress"
+
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # Même préparation mais APP_ENV=test
       - name: Prepare env for CI (.env.dist + .env)
         run: |
           cat > .env.dist <<'EOF'
@@ -76,13 +74,11 @@ jobs:
           MYSQL_USER=app
           MYSQL_PASSWORD=app
           MYSQL_DATABASE=app
-
           APP_ENV=test
           APP_DEBUG=0
           MAILER_DSN=null://localhost
           PMA_HOST=mysql
           PMA_PORT=3306
-
           DATABASE_URL="mysql://app:app@mysql:3306/app?serverVersion=8.4.5&charset=utf8mb4"
           EOF
           cp .env.dist .env

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,10 @@ test:
 db-reset:
 	docker compose down -v
 	docker compose up -d
+
+
+.PHONY: lint
+
+lint:
+	docker compose exec -T -w /var/www/app php php vendor/bin/ecs check --config=/var/www/ecs.php --no-interaction
+	docker compose exec -T -w /var/www/app php php vendor/bin/phpstan analyse -c /var/www/app/phpstan.dist.neon --no-progress

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ db-reset:
 lint:
 	docker compose exec -T -w /var/www/app php php vendor/bin/ecs check --config=/var/www/ecs.php --no-interaction
 	docker compose exec -T -w /var/www/app php php vendor/bin/phpstan analyse -c /var/www/app/phpstan.dist.neon --no-progress
+
+.PHONY: lint-fix
+lint-fix:
+	docker compose exec -T -w /var/www/app php php vendor/bin/ecs check --config=/var/www/ecs.php --no-interaction --fix

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ down:       # stop & remove volumes (-v)
 logs:       # logs suivis (--tail=100)
 test:       # lance la suite de tests (APP_ENV=test)
 db-reset:   # reset complet de la base puis relance
+lint:       # vérifie le style (ECS) + l'analyse statique (PHPStan)
+lint-fix:   # corrige automatiquement les erreurs ECS
+
 
 Exemples : 
 
@@ -120,6 +123,21 @@ docker compose exec -e APP_ENV=test -w /var/www/app php vendor/bin/simple-phpuni
 # ou simplement
 make test
 ```
+
+## Qualité & hooks Git
+
+- Lint PHP : EasyCodingStandard (config `ecs.php` à la racine)
+- Analyse statique : PHPStan (config `app/phpstan.dist.neon`, extensions Doctrine)
+- Hook `pre-commit` : exécute ECS puis PHPStan et **refuse** le commit si le lint échoue.
+
+Installation locale des hooks :
+docker compose exec -w /var/www php php app/vendor/bin/captainhook install -c /var/www/captainhook.json --only-enabled
+
+Commandes utiles :
+make lint
+make lint-fix
+make test
+
 
 ## Statut
 

--- a/app/composer.json
+++ b/app/composer.json
@@ -21,6 +21,7 @@
         "symfony/yaml": "7.3.*"
     },
     "require-dev": {
+        "captainhook/captainhook": "^5",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-doctrine": "^2.0",
         "symfony/browser-kit": "7.3.*",
@@ -28,6 +29,7 @@
         "symfony/maker-bundle": "^1.64",
         "symfony/phpunit-bridge": "^7.3",
         "symfony/twig-bundle": "7.3.*",
+        "symplify/easy-coding-standard": "^12",
         "twig/extra-bundle": "^2.12|^3.0",
         "twig/twig": "^2.12|^3.0"
     },

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d73409deaa95046d2550638322c3357c",
+    "content-hash": "1223e767dc9b329d6d6fff39b28791a3",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4882,6 +4882,146 @@
     ],
     "packages-dev": [
         {
+            "name": "captainhook/captainhook",
+            "version": "5.25.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/captainhook-git/captainhook.git",
+                "reference": "f2278edde4b45af353861aae413fc3840515bb80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/captainhook-git/captainhook/zipball/f2278edde4b45af353861aae413fc3840515bb80",
+                "reference": "f2278edde4b45af353861aae413fc3840515bb80",
+                "shasum": ""
+            },
+            "require": {
+                "captainhook/secrets": "^0.9.4",
+                "ext-json": "*",
+                "ext-spl": "*",
+                "ext-xml": "*",
+                "php": ">=8.0",
+                "sebastianfeldmann/camino": "^0.9.2",
+                "sebastianfeldmann/cli": "^3.3",
+                "sebastianfeldmann/git": "^3.14",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "replace": {
+                "sebastianfeldmann/captainhook": "*"
+            },
+            "require-dev": {
+                "composer/composer": "~1 || ^2.0",
+                "mikey179/vfsstream": "~1"
+            },
+            "bin": [
+                "bin/captainhook"
+            ],
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "config": "captainhook.json"
+                },
+                "branch-alias": {
+                    "dev-main": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "CaptainHook\\App\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP git hook manager",
+            "homepage": "http://php.captainhook.info/",
+            "keywords": [
+                "commit-msg",
+                "git",
+                "hooks",
+                "post-merge",
+                "pre-commit",
+                "pre-push",
+                "prepare-commit-msg"
+            ],
+            "support": {
+                "issues": "https://github.com/captainhook-git/captainhook/issues",
+                "source": "https://github.com/captainhook-git/captainhook/tree/5.25.11"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-12T12:14:57+00:00"
+        },
+        {
+            "name": "captainhook/secrets",
+            "version": "0.9.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/captainhook-git/secrets.git",
+                "reference": "d62c97f75f81ac98e22f1c282482bd35fa82f631"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/captainhook-git/secrets/zipball/d62c97f75f81ac98e22f1c282482bd35fa82f631",
+                "reference": "d62c97f75f81ac98e22f1c282482bd35fa82f631",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CaptainHook\\Secrets\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "Utility classes to detect secrets",
+            "keywords": [
+                "commit-msg",
+                "keys",
+                "passwords",
+                "post-merge",
+                "prepare-commit-msg",
+                "secrets",
+                "tokens"
+            ],
+            "support": {
+                "issues": "https://github.com/captainhook-git/secrets/issues",
+                "source": "https://github.com/captainhook-git/secrets/tree/0.9.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-08T07:10:48+00:00"
+        },
+        {
             "name": "masterminds/html5",
             "version": "2.9.0",
             "source": {
@@ -5008,16 +5148,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.17",
+            "version": "2.1.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
+                "reference": "b13345001a8553ec405b7741be0c6b8d7f8b5bf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b13345001a8553ec405b7741be0c6b8d7f8b5bf5",
+                "reference": "b13345001a8553ec405b7741be0c6b8d7f8b5bf5",
                 "shasum": ""
             },
             "require": {
@@ -5062,20 +5202,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:55:28+00:00"
+            "time": "2025-09-16T11:33:46+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "eeff19808f8ae3a6f7c4e43e388a2848eb2b0865"
+                "reference": "934f5734812341358fc41c44006b30fa00c785f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/eeff19808f8ae3a6f7c4e43e388a2848eb2b0865",
-                "reference": "eeff19808f8ae3a6f7c4e43e388a2848eb2b0865",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/934f5734812341358fc41c44006b30fa00c785f0",
+                "reference": "934f5734812341358fc41c44006b30fa00c785f0",
                 "shasum": ""
             },
             "require": {
@@ -5132,9 +5272,185 @@
             "description": "Doctrine extensions for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.5"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.6"
             },
-            "time": "2025-09-07T11:52:30+00:00"
+            "time": "2025-09-10T07:06:30+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/camino",
+            "version": "0.9.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/camino.git",
+                "reference": "bf2e4c8b2a029e9eade43666132b61331e3e8184"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/camino/zipball/bf2e4c8b2a029e9eade43666132b61331e3e8184",
+                "reference": "bf2e4c8b2a029e9eade43666132b61331e3e8184",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Camino\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "Path management the OO way",
+            "homepage": "https://github.com/sebastianfeldmann/camino",
+            "keywords": [
+                "file system",
+                "path"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/camino/issues",
+                "source": "https://github.com/sebastianfeldmann/camino/tree/0.9.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-03T13:15:10+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/cli",
+            "version": "3.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/cli.git",
+                "reference": "6fa122afd528dae7d7ec988a604aa6c600f5d9b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/cli/zipball/6fa122afd528dae7d7ec988a604aa6c600f5d9b5",
+                "reference": "6fa122afd528dae7d7ec988a604aa6c600f5d9b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "symfony/process": "^4.3 | ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Cli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP cli helper classes",
+            "homepage": "https://github.com/sebastianfeldmann/cli",
+            "keywords": [
+                "cli"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/cli/issues",
+                "source": "https://github.com/sebastianfeldmann/cli/tree/3.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-26T10:19:01+00:00"
+        },
+        {
+            "name": "sebastianfeldmann/git",
+            "version": "3.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianfeldmann/git.git",
+                "reference": "90cb5a32f54dbb0d7dcd87d02e664ec2b50c0c96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianfeldmann/git/zipball/90cb5a32f54dbb0d7dcd87d02e664ec2b50c0c96",
+                "reference": "90cb5a32f54dbb0d7dcd87d02e664ec2b50c0c96",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "php": ">=8.0",
+                "sebastianfeldmann/cli": "^3.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SebastianFeldmann\\Git\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Feldmann",
+                    "email": "sf@sebastian-feldmann.info"
+                }
+            ],
+            "description": "PHP git wrapper",
+            "homepage": "https://github.com/sebastianfeldmann/git",
+            "keywords": [
+                "git"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianfeldmann/git/issues",
+                "source": "https://github.com/sebastianfeldmann/git/tree/3.15.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianfeldmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-05T08:07:09+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -5769,6 +6085,67 @@
                 }
             ],
             "time": "2025-06-24T04:04:43+00:00"
+        },
+        {
+            "name": "symplify/easy-coding-standard",
+            "version": "12.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/easy-coding-standard/easy-coding-standard.git",
+                "reference": "781e6124dc7e14768ae999a8f5309566bbe62004"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/781e6124dc7e14768ae999a8f5309566bbe62004",
+                "reference": "781e6124dc7e14768ae999a8f5309566bbe62004",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "conflict": {
+                "friendsofphp/php-cs-fixer": "<3.46",
+                "phpcsstandards/php_codesniffer": "<3.8",
+                "symplify/coding-standard": "<12.1"
+            },
+            "suggest": {
+                "ext-dom": "Needed to support checkstyle output format in class CheckstyleOutputFormatter"
+            },
+            "bin": [
+                "bin/ecs"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
+            "keywords": [
+                "Code style",
+                "automation",
+                "fixer",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/easy-coding-standard/easy-coding-standard/issues",
+                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-10T14:21:58+00:00"
         },
         {
             "name": "twig/extra-bundle",

--- a/app/config/bundles.php
+++ b/app/config/bundles.php
@@ -1,11 +1,26 @@
 <?php
 
 return [
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
-    Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
-    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
-    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => [
+        'all' => true,
+    ],
+    Symfony\Bundle\MakerBundle\MakerBundle::class => [
+        'dev' => true,
+    ],
+    Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => [
+        'all' => true,
+    ],
+    Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => [
+        'all' => true,
+    ],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => [
+        'all' => true,
+    ],
+    Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => [
+        'dev' => true,
+        'test' => true,
+    ],
+    Symfony\Bundle\SecurityBundle\SecurityBundle::class => [
+        'all' => true,
+    ],
 ];

--- a/app/config/preload.php
+++ b/app/config/preload.php
@@ -1,5 +1,5 @@
 <?php
 
-if (file_exists(dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php')) {
-    require dirname(__DIR__).'/var/cache/prod/App_KernelProdContainer.preload.php';
+if (file_exists(dirname(__DIR__) . '/var/cache/prod/App_KernelProdContainer.preload.php')) {
+    require dirname(__DIR__) . '/var/cache/prod/App_KernelProdContainer.preload.php';
 }

--- a/app/public/index.php
+++ b/app/public/index.php
@@ -2,9 +2,11 @@
 
 use App\Kernel;
 
-require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+require_once dirname(__DIR__) . '/vendor/autoload_runtime.php';
 
 return function (array $context) {
-    return new Kernel(is_string($context['APP_ENV']) ? $context['APP_ENV'] : '',
-    (bool) $context['APP_DEBUG']);
+    return new Kernel(
+        is_string($context['APP_ENV']) ? $context['APP_ENV'] : '',
+        (bool) $context['APP_DEBUG']
+    );
 };

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -13,7 +13,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\HasLifecycleCallbacks]
 class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
-
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -47,7 +46,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->updatedAt = $now;
     }
 
-    /** @return int|null */
+    /**
+     * Empêche la sérialisation de hash réels en session (Symfony ≥ 7.3).
+     */
+    public function __serialize(): array
+    {
+        $data = (array) $this;
+        $data["\0" . self::class . "\0password"] = hash('crc32c', $this->password);
+
+        return $data;
+    }
+
     public function getId(): ?int
     {
         return $this->id;
@@ -65,9 +74,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getUserIdentifier(): string
     {
         return $this->email;
@@ -96,9 +102,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
@@ -109,17 +112,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->password = $password;
 
         return $this;
-    }
-
-    /**
-     * Empêche la sérialisation de hash réels en session (Symfony ≥ 7.3).
-     */
-    public function __serialize(): array
-    {
-        $data = (array) $this;
-        $data["\0".self::class."\0password"] = hash('crc32c', $this->password);
-
-        return $data;
     }
 
     public function eraseCredentials(): void
@@ -156,5 +148,4 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         $this->updatedAt = new \DateTimeImmutable();
     }
-
 }

--- a/app/src/Kernel.php
+++ b/app/src/Kernel.php
@@ -3,8 +3,8 @@
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class Kernel extends BaseKernel
@@ -14,14 +14,14 @@ class Kernel extends BaseKernel
     protected function configureContainer(ContainerConfigurator $container): void
     {
         $container->import('../config/{packages}/*.yaml');
-        $container->import('../config/{packages}/'.$this->environment.'/*.yaml');
+        $container->import('../config/{packages}/' . $this->environment . '/*.yaml');
         $container->import('../config/{services}.yaml');
-        $container->import('../config/{services}_'.$this->environment.'.yaml');
+        $container->import('../config/{services}_' . $this->environment . '.yaml');
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
-        $routes->import('../config/{routes}/'.$this->environment.'/*.yaml');
+        $routes->import('../config/{routes}/' . $this->environment . '/*.yaml');
         $routes->import('../config/{routes}/*.yaml');
         $routes->import('../config/{routes}.yaml');
     }

--- a/app/src/Repository/UserRepository.php
+++ b/app/src/Repository/UserRepository.php
@@ -24,7 +24,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
      */
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
-        if (!$user instanceof User) {
+        if (! $user instanceof User) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', $user::class));
         }
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/captainhookphp/captainhook/main/config-schema.json",
+  "config": {
+    "bootstrap": "app/vendor/autoload.php",
+    "validate": true
+  },
+  "pre-commit": {
+    "enabled": true,
+    "actions": [
+      {
+        "action": "\\CaptainHook\\App\\Hook\\Action\\Cli",
+        "options": { "exec": "make lint" }
+      }
+    ]
+  }
+}

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,16 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/captainhookphp/captainhook/main/config-schema.json",
-  "config": {
-    "bootstrap": "app/vendor/autoload.php",
-    "validate": true
-  },
+  "config": { "bootstrap": "app/vendor/autoload.php", "validate": true },
   "pre-commit": {
     "enabled": true,
     "actions": [
-      {
-        "action": "\\CaptainHook\\App\\Hook\\Action\\Cli",
-        "options": { "exec": "make lint" }
-      }
+      { "action": "php app/vendor/bin/ecs check --config=/var/www/ecs.php --no-interaction" },
+      { "action": "php app/vendor/bin/phpstan analyse -c /var/www/app/phpstan.dist.neon --no-progress" }
     ]
   }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -2,8 +2,32 @@
 
 declare(strict_types=1);
 
-use ECSPrefix202401\Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 return static function (ECSConfig $ecsConfig): void {
-    // règles ajoutées dans F-003
+    // Dossiers analysés – adapte si besoin
+    $ecsConfig->paths([
+        __DIR__ . '/app/src',
+        __DIR__ . '/app/tests',
+        __DIR__ . '/app/bin',
+        __DIR__ . '/app/config',
+        __DIR__ . '/app/public',
+    ]);
+
+    // Exclusions utiles
+    $ecsConfig->skip([
+        __DIR__ . '/var/*',
+        __DIR__ . '/vendor/*',
+    ]);
+
+    // Jeux de règles recommandés
+    $ecsConfig->sets([
+        SetList::PSR_12,
+        SetList::CLEAN_CODE,
+        SetList::COMMON,
+    ]);
+
+    // Tes règles F-003 / custom peuvent être ajoutées ici
+    // ex: $ecsConfig->rule(\PhpCsFixer\Fixer\Import\NoUnusedImportsFixer::class);
 };


### PR DESCRIPTION
## Objectif
Empêcher tout commit non propre en exécutant ECS + PHPStan en pre-commit et ajouter les mêmes vérifications en CI.

## Changements
- CaptainHook v5 installé ; hook `pre-commit` exécuté dans Docker
- `captainhook.json` : actions `ecs` puis `phpstan`
- Makefile : cibles `lint` et `lint-fix`
- README : section “Qualité & hooks Git”
- CI (`.github/workflows/ci.yml`) : étapes “ECS check” et “PHPStan analyse”

## Tests / Vérifications
- `make lint` OK en local
- Hook bloquant si lint échoue (`git commit --allow-empty` testé)
- CI verte sur cette PR

## Lié à
Closes #16

## Points de vérification
- [x] Linter et CI verts
- [x] Tests passent (`make test`) si présents
- [x] Documentation mise à jour
- [x] Aucun secret ou fichier généré commité

## Screenshots (si UI)
<!-- Ajoute une capture avant/après si pertinent -->
