### PR TITLE
Feat/f 009 dependabot + auto-merge patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/app"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "composer"
+    commit-message:
+      prefix: "build(composer)"
+      include: "scope"
+    groups:
+      composer-patch:
+        update-types:
+          - "patch"

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,29 @@
+name: Auto-merge Dependabot patch updates
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge for semver patch
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash) when patch and CI is green
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![CI](https://github.com/Adrien1988/recherche-emploi/actions/workflows/ci.yml/badge.svg)](https://github.com/Adrien1988/recherche-emploi/actions/workflows/ci.yml)
+[![Dependencies](https://img.shields.io/badge/dependencies-automated-blue?logo=dependabot)](https://github.com/Adrien1988/recherche-emploi/security/dependabot)
+
 
 
 # Recherche d’emploi – Suivi, relances et rapports en un seul outil


### PR DESCRIPTION
## Objectif
Mettre en place la mise à jour automatique des dépendances Composer via Dependabot, 
et configurer l’auto-merge des mises à jour de patch-versions uniquement si la CI est verte. 
Ajout d’un badge “Dependencies” dans le README pour la visibilité.

## Lié à
Closes #17

## Points de vérification
- [x] Tests unitaires et intégration passent (`make test`)
- [x] Linter et CI verts (`CI / lint`, `CI / test`)
- [x] Documentation mise à jour (README avec badge Dependencies)
- [x] Aucun secret ou fichier généré commités

## Screenshots (si UI)
N/A (pas de composant visuel, uniquement configuration GitHub)
