### PR TITLE
Feat/I 001 pipeline CD (build-only)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,26 +17,20 @@ concurrency:
 
 jobs:
   deploy:
-    # Ne déploie que si: déclenchement manuel OU CI verte sur main
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
 
-    # On expose les secrets dans l'env du job, puis on s'en sert dans les "if" des steps
     env:
-      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      # Tag = SHA du run courant (dispatch) ou du run CI source (workflow_run)
       IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
 
-      # Déploiement Fly.io (vide si non défini)
+      # Secrets exposés en env (vides si non définis) pour faciliter les conditions
       FLY_APP_NAME: ${{ secrets.FLY_APP_NAME }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-      # Déploiement VPS via SSH (vides si non définis)
       SSH_HOST: ${{ secrets.SSH_HOST }}
       SSH_USER: ${{ secrets.SSH_USER }}
       SSH_PORT: ${{ secrets.SSH_PORT }}
       REMOTE_COMPOSE_PATH: ${{ secrets.REMOTE_COMPOSE_PATH }}
-
-      # Notifications (vides si non définies)
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
       MAIL_PORT: ${{ secrets.MAIL_PORT }}
@@ -51,6 +45,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.IMAGE_TAG }}
+
+      - name: Compute lowercase image name (GHCR)
+        id: img
+        shell: bash
+        run: |
+          echo "image_name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -71,21 +71,21 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ steps.img.outputs.image_name }}:${{ env.IMAGE_TAG }}
+            ${{ steps.img.outputs.image_name }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # ---------- Déploiement Fly.io (optionnel) ----------
+      # ---------- Fly.io (optionnel) ----------
       - name: Deploy to Fly.io
         if: ${{ env.FLY_APP_NAME != '' && env.FLY_API_TOKEN != '' }}
         uses: superfly/flyctl-actions@v1
         with:
-          args: deploy --app ${{ env.FLY_APP_NAME }} --image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          args: deploy --app ${{ env.FLY_APP_NAME }} --image ${{ steps.img.outputs.image_name }}:${{ env.IMAGE_TAG }}
         env:
           FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
 
-      # ---------- Déploiement VPS via SSH (optionnel) ----------
+      # ---------- VPS via SSH (optionnel) ----------
       - name: Deploy to VPS via SSH
         if: ${{ env.SSH_HOST != '' && env.SSH_USER != '' && env.REMOTE_COMPOSE_PATH != '' }}
         env:
@@ -94,7 +94,7 @@ jobs:
           SSH_PORT: ${{ env.SSH_PORT || 22 }}
           REMOTE_COMPOSE_PATH: ${{ env.REMOTE_COMPOSE_PATH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_NAME: ${{ steps.img.outputs.image_name }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN"
@@ -103,12 +103,12 @@ jobs:
           ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH up -d"
           ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "docker image prune -f"
 
-      # ---------- Notifications en cas d'échec (optionnelles) ----------
+      # ---------- Notifications échec (optionnel) ----------
       - name: Notify failure to Slack
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\"CD failed on $GITHUB_REPOSITORY@$IMAGE_TAG — run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            --data "{\"text\":\"CD failed on $GITHUB_REPOSITORY@${{ env.IMAGE_TAG }} — run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
             "${{ env.SLACK_WEBHOOK_URL }}"
 
       - name: Notify failure by email

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,8 +90,10 @@ jobs:
           server_port: ${{ secrets.MAIL_PORT || 587 }}
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: CD failed: ${{ github.repository }} @ ${{ env.IMAGE_TAG }}
+          subject: "CD failed: ${{ github.repository }} @ ${{ env.IMAGE_TAG }}"
           to: ${{ secrets.MAIL_TO }}
           from: ${{ secrets.MAIL_FROM }}
           secure: ${{ secrets.MAIL_SECURE || 'starttls' }}
-          body: CD failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          body: |
+            CD failed.
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,97 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: cd-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+      IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.IMAGE_TAG }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Fly.io
+        if: ${{ secrets.FLY_API_TOKEN && secrets.FLY_APP_NAME }}
+        uses: superfly/flyctl-actions@v1
+        with:
+          args: deploy --app ${{ secrets.FLY_APP_NAME }} --image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy to VPS via SSH
+        if: ${{ secrets.SSH_HOST && secrets.SSH_USER && secrets.REMOTE_COMPOSE_PATH }}
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
+          REMOTE_COMPOSE_PATH: ${{ secrets.REMOTE_COMPOSE_PATH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: |
+          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN"
+          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker pull $IMAGE_NAME:$IMAGE_TAG"
+          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH pull"
+          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH up -d"
+          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker image prune -f"
+
+      - name: Notify failure to Slack
+        if: failure() && secrets.SLACK_WEBHOOK_URL
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"CD failed on $GITHUB_REPOSITORY@$IMAGE_TAG — run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify failure by email
+        if: failure() && secrets.MAIL_SERVER && secrets.MAIL_TO && secrets.MAIL_FROM && secrets.MAIL_USERNAME && secrets.MAIL_PASSWORD
+        uses: dawidd6/action-send-mail@v6
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT || 587 }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: CD failed: ${{ github.repository }} @ ${{ env.IMAGE_TAG }}
+          to: ${{ secrets.MAIL_TO }}
+          from: ${{ secrets.MAIL_FROM }}
+          secure: ${{ secrets.MAIL_SECURE || 'starttls' }}
+          body: CD failed. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Tag = SHA du run courant (dispatch) ou du run CI source (workflow_run)
       IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
 
-      # Secrets exposés en env (vides si non définis) pour faciliter les conditions
       FLY_APP_NAME: ${{ secrets.FLY_APP_NAME }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -52,6 +50,34 @@ jobs:
         run: |
           echo "image_name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
+      - name: Locate Dockerfile (auto)
+        id: dfile
+        shell: bash
+        run: |
+          set -euo pipefail
+          CANDIDATES=(
+            "Dockerfile"
+            "app/Dockerfile"
+            "docker/Dockerfile"
+            "docker/php/Dockerfile"
+            "infrastructure/Dockerfile"
+            "deploy/Dockerfile"
+          )
+          for p in "${CANDIDATES[@]}"; do
+            if [ -f "$p" ]; then
+              echo "path=$p" >> "$GITHUB_OUTPUT"
+              # contexte = dossier du Dockerfile (ou '.' s'il est à la racine)
+              dir="$(dirname "$p")"
+              if [ "$dir" = "." ]; then dir="."; fi
+              echo "context=$dir" >> "$GITHUB_OUTPUT"
+              echo "Found Dockerfile at: $p (context: $dir)"
+              exit 0
+            fi
+          done
+          echo "Aucun Dockerfile trouvé aux emplacements connus." 1>&2
+          echo "Crée un Dockerfile (ex: app/Dockerfile) ou adapte la liste des chemins." 1>&2
+          exit 1
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -68,7 +94,8 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ steps.dfile.outputs.context }}
+          file: ${{ steps.dfile.outputs.path }}
           push: true
           tags: |
             ${{ steps.img.outputs.image_name }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,35 @@ concurrency:
 
 jobs:
   deploy:
+    # Ne déploie que si: déclenchement manuel OU CI verte sur main
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
+
+    # On expose les secrets dans l'env du job, puis on s'en sert dans les "if" des steps
     env:
       IMAGE_NAME: ghcr.io/${{ github.repository }}
       IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+
+      # Déploiement Fly.io (vide si non défini)
+      FLY_APP_NAME: ${{ secrets.FLY_APP_NAME }}
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # Déploiement VPS via SSH (vides si non définis)
+      SSH_HOST: ${{ secrets.SSH_HOST }}
+      SSH_USER: ${{ secrets.SSH_USER }}
+      SSH_PORT: ${{ secrets.SSH_PORT }}
+      REMOTE_COMPOSE_PATH: ${{ secrets.REMOTE_COMPOSE_PATH }}
+
+      # Notifications (vides si non définies)
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      MAIL_SERVER: ${{ secrets.MAIL_SERVER }}
+      MAIL_PORT: ${{ secrets.MAIL_PORT }}
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+      MAIL_FROM: ${{ secrets.MAIL_FROM }}
+      MAIL_TO: ${{ secrets.MAIL_TO }}
+      MAIL_SECURE: ${{ secrets.MAIL_SECURE }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,7 +58,7 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login GHCR
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -52,48 +76,53 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # ---------- Déploiement Fly.io (optionnel) ----------
       - name: Deploy to Fly.io
-        if: ${{ secrets.FLY_API_TOKEN && secrets.FLY_APP_NAME }}
+        if: ${{ env.FLY_APP_NAME != '' && env.FLY_API_TOKEN != '' }}
         uses: superfly/flyctl-actions@v1
         with:
-          args: deploy --app ${{ secrets.FLY_APP_NAME }} --image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          args: deploy --app ${{ env.FLY_APP_NAME }} --image ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
 
+      # ---------- Déploiement VPS via SSH (optionnel) ----------
       - name: Deploy to VPS via SSH
-        if: ${{ secrets.SSH_HOST && secrets.SSH_USER && secrets.REMOTE_COMPOSE_PATH }}
+        if: ${{ env.SSH_HOST != '' && env.SSH_USER != '' && env.REMOTE_COMPOSE_PATH != '' }}
         env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
-          REMOTE_COMPOSE_PATH: ${{ secrets.REMOTE_COMPOSE_PATH }}
+          SSH_HOST: ${{ env.SSH_HOST }}
+          SSH_USER: ${{ env.SSH_USER }}
+          SSH_PORT: ${{ env.SSH_PORT || 22 }}
+          REMOTE_COMPOSE_PATH: ${{ env.REMOTE_COMPOSE_PATH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN"
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker pull $IMAGE_NAME:$IMAGE_TAG"
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH pull"
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH up -d"
-          ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "docker image prune -f"
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "docker login ghcr.io -u $GITHUB_ACTOR -p $GITHUB_TOKEN"
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "docker pull $IMAGE_NAME:$IMAGE_TAG"
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH pull"
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "IMAGE=$IMAGE_NAME:$IMAGE_TAG docker compose -f $REMOTE_COMPOSE_PATH up -d"
+          ssh -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "docker image prune -f"
 
+      # ---------- Notifications en cas d'échec (optionnelles) ----------
       - name: Notify failure to Slack
-        if: failure() && secrets.SLACK_WEBHOOK_URL
+        if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
         run: |
-          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"CD failed on $GITHUB_REPOSITORY@$IMAGE_TAG — run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" ${{ secrets.SLACK_WEBHOOK_URL }}
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"CD failed on $GITHUB_REPOSITORY@$IMAGE_TAG — run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            "${{ env.SLACK_WEBHOOK_URL }}"
 
       - name: Notify failure by email
-        if: failure() && secrets.MAIL_SERVER && secrets.MAIL_TO && secrets.MAIL_FROM && secrets.MAIL_USERNAME && secrets.MAIL_PASSWORD
-        uses: dawidd6/action-send-mail@v6
+        if: ${{ failure() && env.MAIL_SERVER != '' && env.MAIL_FROM != '' && env.MAIL_TO != '' && env.MAIL_USERNAME != '' && env.MAIL_PASSWORD != '' }}
+        uses: dawidd6/action-send-mail@v3
         with:
-          server_address: ${{ secrets.MAIL_SERVER }}
-          server_port: ${{ secrets.MAIL_PORT || 587 }}
-          username: ${{ secrets.MAIL_USERNAME }}
-          password: ${{ secrets.MAIL_PASSWORD }}
+          server_address: ${{ env.MAIL_SERVER }}
+          server_port: ${{ env.MAIL_PORT || 587 }}
+          username: ${{ env.MAIL_USERNAME }}
+          password: ${{ env.MAIL_PASSWORD }}
           subject: "CD failed: ${{ github.repository }} @ ${{ env.IMAGE_TAG }}"
-          to: ${{ secrets.MAIL_TO }}
-          from: ${{ secrets.MAIL_FROM }}
-          secure: ${{ secrets.MAIL_SECURE || 'starttls' }}
+          to: ${{ env.MAIL_TO }}
+          from: ${{ env.MAIL_FROM }}
+          secure: ${{ env.MAIL_SECURE || 'starttls' }}
           body: |
             CD failed.
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Objectif
Mettre en place un pipeline CD déclenché automatiquement après CI verte, en mode “build-only” provisoire (pas d’environnement de prod pour l’instant).  
Le workflow `deploy.yml` :
- est déclenché par `workflow_run` après succès du workflow **CI** sur `main` ;
- construit l’image Docker et la pousse sur GHCR (`latest` + tag SHA), avec nom d’image en minuscules ;
- détecte automatiquement l’emplacement du Dockerfile (racine, app/, docker/, …) et ajuste le contexte ;
- prépare (mais n’exécute pas) les déploiements **Fly.io** / **VPS via SSH** tant que les secrets ne sont pas définis ;
- prévoit des notifications d’échec (Slack/e-mail) si secrets fournis.

Justification “build-only” : pas d’environnement de prod actif à ce jour. On réduit néanmoins le time-to-prod en rendant l’image dispo immédiatement après CI.

## Lié à
Closes #33

## Points de vérification
- [X] **CI verte sur `main`**
  - Ouvrir *Actions → CI* et vérifier le dernier run `main` = ✅.
  - Confirmer que les étapes **ECS**, **PHPStan** et **Tests** passent.
- [X] **CD déclenché automatiquement post-CI (ou manuellement pour test)**
  - Déclencher si besoin : *Actions → CD → Run workflow* (branche `main` ou la branche de test).
  - Vérifier que l’événement du run CD est `workflow_run` (ou `workflow_dispatch` si manuel).
- [X] **Build & push de l’image GHCR OK**
  - Dans le run **CD**, l’étape **“Build and push image”** doit être ✅.
  - Dans *Packages* du repo, vérifier le container avec les tags **`latest`** et **le SHA** du commit.
- [X] **Étapes de déploiement désactivées (attendu en build-only)**
  - Dans le run **CD**, les steps **“Deploy to Fly.io”** et **“Deploy to VPS via SSH”** doivent être **Skipped** (aucun secret défini).
- [X] **Permissions Actions correctes**
  - *Settings → Actions → General → Workflow permissions* = **Read and write permissions**.
- [X] **Documentation mise à jour**
  - Badge CD ajouté dans le `README.md` :  
    `![CD](https://github.com/Adrien1988/recherche-emploi/actions/workflows/deploy.yml/badge.svg)`
  - Note courte “mode build-only” dans le README (déploiement activable par secrets).
- [X] **Hygiène / sécurité**
  - Aucun secret ou fichier généré committé (pas de `.env`, clés, certificats, etc.).
  - Le workflow n’expose aucun secret en clair (uniquement `${{ secrets.* }}`).

## Screenshots (si UI)
<!-- Ajoute une capture avant/après si pertinent -->
